### PR TITLE
Add macOS 27 (Golden_Gate) support

### DIFF
--- a/Create_Install_Media.command
+++ b/Create_Install_Media.command
@@ -1,6 +1,6 @@
 #!/usr/bin/osascript
 #
-# Create Install Media, Copyright (c) 2024 chris1111. All Right Reserved.
+# Create Install Media, Copyright (c) 2024, 2026 chris1111. All Right Reserved.
 # Credit: Apple
 # Version "1.0"
 # AppleScript Code
@@ -12,7 +12,7 @@ Welcome Create Install Media
 to create macOS Install drive.
 --------------------------
 You can create a bootable USB key 
-from macOS High Sierra 10.13 to macOS Sequoia 15
+from macOS High Sierra 10.13 to macOS Tahoe 26
 		
 Format your USB Drive with Disk Utility 
 in the format Mac OS Extended (Journaled) 
@@ -45,9 +45,9 @@ To continue, select the volume you want to use, then press the OK button" OK but
 	try
 		--If Continue
 		set theAction to button returned of (display dialog "
-Choose the location of your Install macOS.app" with icon 2 buttons {"Quit", "10.13 to Sequoia 15"} cancel button "Quit" default button {"10.13 to Sequoia 15"})
-		if theAction = "10.13 to Sequoia 15" then
-			--If 10.13 to Sequoia 15
+Choose the location of your Install macOS.app" with icon 2 buttons {"Quit", "10.13 to Tahoe 26"} cancel button "Quit" default button {"10.13 to Tahoe 26"})
+		if theAction = "10.13 to Tahoe 26" then
+			--If 10.13 to Tahoe 26
 			
 			set InstallOSX to choose file of type {"XLSX", "APPL"} default location (path to applications folder) with prompt "Choose your Install macOS.app"
 			set OSXInstaller to POSIX path of InstallOSX

--- a/creator.command
+++ b/creator.command
@@ -8,14 +8,14 @@ set -e
 # but I tried to implement using pure Bash 3 without GNU coreutils.
 # - heinthanth ( Hein Thant Maung Maung )
 
-CATALOG_URL="https://swscan.apple.com/content/catalogs/others/index-26seed-26-15-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog"
+CATALOG_URL="https://swscan.apple.com/content/catalogs/others/index-27seed-27-26-15-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog"
 
 printf "\n\e[33mDownload Install macOS [v1.0.1]\e[0m\n\n"
 
 printf '\e[8;40;82t'
 
 # Download Install macOS
-# RELEASE AND BETA_Tahoe
+# RELEASE AND BETA_Golden_Gate
 
 # DOWNLOADING CATALOG
 CATALOG="/Private/tmp/sucatalog.plist"
@@ -103,7 +103,9 @@ MAJOR_VERSION=$(echo $SELECTED_BUILD_INFO | cut -d, -f1 | cut -d. -f1,2)
 BASE_URL=$(echo $SELECTED_BUILD_INFO | cut -d, -f3)
 MACOS_VERSION=""
 
-if [[ "$MAJOR_VERSION" == "26."* ]]; then
+if [[ "$MAJOR_VERSION" == "27."* ]]; then
+    MACOS_VERSION="Golden_Gate"
+elif [[ "$MAJOR_VERSION" == "26."* ]]; then
     MACOS_VERSION="Tahoe"
 elif [[ "$MAJOR_VERSION" == "15."* ]]; then
     MACOS_VERSION="Sequoia"
@@ -128,7 +130,7 @@ fi
 INSTALLATION_FILES=()
 # DOWNLOADING_INSTALLATION_FILES
 INSTALLATION_FILES=()
-if [[ $MACOS_VERSION == "Tahoe" ]] || [[ $MACOS_VERSION == "Sequoia" ]] || [[ $MACOS_VERSION == "Sonoma" ]] || [[ "$MACOS_VERSION" == "Ventura" ]] || [[ "$MACOS_VERSION" == "Monterey" ]] || [[ "$MACOS_VERSION" == "BigSur" ]]; then
+if [[ $MACOS_VERSION == "Golden_Gate" ]] || [[ $MACOS_VERSION == "Tahoe" ]] || [[ $MACOS_VERSION == "Sequoia" ]] || [[ $MACOS_VERSION == "Sonoma" ]] || [[ "$MACOS_VERSION" == "Ventura" ]] || [[ "$MACOS_VERSION" == "Monterey" ]] || [[ "$MACOS_VERSION" == "BigSur" ]]; then
     INSTALLATION_FILES=("InstallAssistant.pkg")
 else
     INSTALLATION_FILES=("BaseSystem.chunklist" "InstallInfo.plist" "AppleDiagnostics.dmg" "AppleDiagnostics.chunklist" "BaseSystem.dmg" "InstallESDDmg.pkg")


### PR DESCRIPTION
Update installer scripts to support the next macOS catalog and adjust UI labels. Changes:
- creator.command: point CATALOG_URL to the index-27seed catalog, add MAJOR_VERSION == 27 mapping to "Golden_Gate", and include "Golden_Gate" in the branch that uses InstallAssistant.pkg. Also update a release comment.
- Create_Install_Media.command: update to reference Tahoe 26 (replacing Sequoia 15 where applicable). These changes enable the scripts to detect and handle macOS 27 builds and refresh the displayed labels/metadata.